### PR TITLE
[WIP] Add QueueNotification for generic Discord messages

### DIFF
--- a/src/ChatTransmitter.cpp
+++ b/src/ChatTransmitter.cpp
@@ -8,6 +8,7 @@
 #include "Requests/RequestQueryResult.h"
 #include "Requests/RequestCommandResult.h"
 #include "Requests/RequestAnticheatReport.h"
+#include "Requests/RequestNotification.h"
 
 #if __has_include("mod-anticheat/src/AnticheatMgr.h")
 #include "mod-anticheat/src/AnticheatMgr.h"
@@ -85,6 +86,14 @@ namespace ModChatTransmitter
         if (wsClient && IsEnabled())
         {
             QueueRequest(new Requests::ChatChannel(player, type, msg, channel));
+        }
+    }
+
+    void ChatTransmitter::QueueNotification(std::string const& source, std::string const& message)
+    {
+        if (wsClient && IsEnabled())
+        {
+            QueueRequest(new Requests::Notification(source, message));
         }
     }
 

--- a/src/ChatTransmitter.h
+++ b/src/ChatTransmitter.h
@@ -35,6 +35,9 @@ namespace ModChatTransmitter
 
         void QueueChat(Player* player, uint32 type, std::string& msg);
         void QueueChat(Player* player, uint32 type, std::string& msg, Channel* channel);
+
+        // Generic entry point for other modules to push a Discord notification.
+        void QueueNotification(std::string const& source, std::string const& message);
         void Update();
         void Stop();
         void Start();
@@ -59,5 +62,7 @@ namespace ModChatTransmitter
         DatabaseManager* dbManager;
     };
 }
+
+#define sChatTransmitter (&ModChatTransmitter::ChatTransmitter::Instance())
 
 #endif // _MOD_CHAT_TRANSMITTER_H_

--- a/src/Requests/RequestNotification.cpp
+++ b/src/Requests/RequestNotification.cpp
@@ -1,0 +1,19 @@
+#include "RequestNotification.h"
+#include "../ChatTransmitter.h"
+
+namespace ModChatTransmitter::Requests
+{
+    Notification::Notification(std::string const& source, std::string const& message)
+        : guildId(ChatTransmitter::Instance().GetDiscordGuildId()),
+        source(source),
+        message(message)
+    { }
+
+    std::string Notification::GetContents()
+    {
+        nlohmann::json jsonObj;
+        jsonObj["message"] = "notification";
+        nlohmann::to_json(jsonObj["data"], *this);
+        return nlohmann::to_string(jsonObj);
+    }
+}

--- a/src/Requests/RequestNotification.h
+++ b/src/Requests/RequestNotification.h
@@ -1,0 +1,27 @@
+#ifndef _MOD_CHAT_TRANSMITTER_REQUESTS_REQUEST_NOTIFICATION_H_
+#define _MOD_CHAT_TRANSMITTER_REQUESTS_REQUEST_NOTIFICATION_H_
+
+#include "../../libs/nlohmann/json.hpp"
+
+#include "../IRequest.h"
+
+namespace ModChatTransmitter::Requests
+{
+    // Generic server-to-Discord notification any module can emit (e.g. a log
+    // event). The bot routes it to a channel keyed by the "source" string.
+    class Notification : public IRequest
+    {
+    public:
+        Notification(std::string const& source, std::string const& message);
+        std::string GetContents() override;
+
+    protected:
+        std::string guildId;
+        std::string source;
+        std::string message;
+
+        NLOHMANN_DEFINE_TYPE_INTRUSIVE(Notification, guildId, source, message)
+    };
+}
+
+#endif // _MOD_CHAT_TRANSMITTER_REQUESTS_REQUEST_NOTIFICATION_H_


### PR DESCRIPTION
> **Draft / WIP.** Emitter side. Becomes functional once the bot handler lands.

## What

- New public `ChatTransmitter::QueueNotification(source, message)`.
- New `Requests::Notification` request, serialized as a `notification` websocket message with `guildId`, `source` and `message`.
- Adds an `sChatTransmitter` singleton macro, matching the convention used by other modules (`sAnticheatMgr`, etc.).

## Why

Lets other modules push a free-text message to Discord through the transmitter, instead of only the built-in chat/anticheat/eluna paths. `source` is a routing key the bot maps to a channel.

## Dependency

Needs the bot-side handler in azerothcore/chat-transmitter-bot#10. Once that merges this is functional and can be marked ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notification queueing functionality enabling the system to dispatch messages with a source identifier and associated content.
  * Introduced a public interface allowing other system components to queue and send notifications using a straightforward string-based approach.
  * Enhanced notification infrastructure to support request serialization and JSON-based message formatting for notification delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->